### PR TITLE
[FAS-6, FAS-7, FAS-8, FAS-9] Verify Firebase JWT on API Routes.

### DIFF
--- a/components/AddSiteModal.js
+++ b/components/AddSiteModal.js
@@ -42,7 +42,7 @@ const AddSiteModal = ({ children }) => {
       isClosable: true
     });
     mutate(
-      '/api/sites',
+      ['/api/sites', auth.user.token],
       async (data) => {
         return { sites: [...data.sites, newSite] };
       },

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useContext, createContext } from 'react';
+import cookie from 'js-cookie';
+
 import firebase from './firebase';
 import { createUser } from './db';
 
@@ -19,12 +21,20 @@ function useProvideAuth() {
   const handleUser = (rawUser) => {
     if (rawUser) {
       const user = formatUser(rawUser);
+      const { token, ...userWithoutToken } = user;
 
-      createUser(user.uid, user);
+      createUser(user.uid, userWithoutToken);
       setUser(user);
+
+      cookie.set('auth', user, {
+        expires: 1
+      });
+
       return user;
     } else {
       setUser(false);
+      cookie.remove('auth');
+
       return false;
     }
   };
@@ -61,6 +71,7 @@ const formatUser = (user) => {
     uid: user.uid,
     email: user.email,
     name: user.displayName,
+    token: user.xa,
     provider: user.providerData[0].providerId,
     photoUrl: user.photoURL
   };

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -26,14 +26,14 @@ function useProvideAuth() {
       createUser(user.uid, userWithoutToken);
       setUser(user);
 
-      cookie.set('auth', user, {
+      cookie.set('fast-feedback-auth', user, {
         expires: 1
       });
 
       return user;
     } else {
       setUser(false);
-      cookie.remove('auth');
+      cookie.remove('fast-feedback-auth');
 
       return false;
     }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -26,7 +26,7 @@ function useProvideAuth() {
       createUser(user.uid, userWithoutToken);
       setUser(user);
 
-      cookie.set('fast-feedback-auth', user, {
+      cookie.set('fast-feedback-auth', true, {
         expires: 1
       });
 

--- a/lib/db-admin.js
+++ b/lib/db-admin.js
@@ -1,10 +1,10 @@
 import { compareDesc, parseISO } from 'date-fns';
 
-import firebase from './firebase-admin';
+import { db } from './firebase-admin';
 
 export async function getAllFeedback(siteId) {
   try {
-    const snapshot = await firebase
+    const snapshot = await db
       .collection('feedback')
       .where('siteId', '==', siteId)
       .get();
@@ -26,16 +26,28 @@ export async function getAllFeedback(siteId) {
 }
 
 export async function getAllSites() {
-  try {
-    const snapshot = await firebase.collection('sites').get();
-    const sites = [];
+  const snapshot = await db.collection('sites').get();
 
-    snapshot.forEach((doc) => {
-      sites.push({ id: doc.id, ...doc.data() });
-    });
+  const sites = [];
 
-    return { sites };
-  } catch (error) {
-    return { error };
-  }
+  snapshot.forEach((doc) => {
+    sites.push({ id: doc.id, ...doc.data() });
+  });
+
+  return { sites };
+}
+
+export async function getUserSites(uid) {
+  const snapshot = await db
+    .collection('sites')
+    .where('authorId', '==', uid)
+    .get();
+
+  const sites = [];
+
+  snapshot.forEach((doc) => {
+    sites.push({ id: doc.id, ...doc.data() });
+  });
+
+  return { sites };
 }

--- a/lib/firebase-admin.js
+++ b/lib/firebase-admin.js
@@ -11,4 +11,7 @@ if (!admin.apps.length) {
   });
 }
 
-export default admin.firestore();
+const db = admin.firestore();
+const auth = admin.auth();
+
+export { db, auth };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "emotion-theming": "^10.0.27",
     "firebase": "^7.14.6",
     "firebase-admin": "^8.12.1",
+    "js-cookie": "^2.2.1",
     "next": "^9.3.3",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",

--- a/pages/api/feedback/[siteId].js
+++ b/pages/api/feedback/[siteId].js
@@ -1,4 +1,4 @@
-import db from '@/lib/firebase-admin';
+import { db } from '@/lib/firebase-admin';
 import { getAllFeedback } from '@/lib/db-admin';
 
 export default async (req, res) => {

--- a/pages/api/sites.js
+++ b/pages/api/sites.js
@@ -1,12 +1,13 @@
-import db from '@/lib/firebase-admin';
-import { getAllSites } from '@/lib/db-admin';
+import { auth } from '@/lib/firebase-admin';
+import { getUserSites } from '@/lib/db-admin';
 
-export default async (_, res) => {
-  const { sites, error } = await getAllSites();
+export default async (req, res) => {
+  try {
+    const { uid } = await auth.verifyIdToken(req.headers.token);
+    const { sites } = await getUserSites(uid);
 
-  if (error) {
+    res.status(200).json({ sites });
+  } catch (error) {
     res.status(500).json({ error });
   }
-
-  res.status(200).json({ sites });
 };

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -8,8 +8,8 @@ import fetcher from '@/utils/fetcher';
 import { useAuth } from '@/lib/auth';
 
 const Dashboard = () => {
-  const auth = useAuth();
-  const { data } = useSWR('/api/sites', fetcher);
+  const { user } = useAuth();
+  const { data } = useSWR(user ? ['/api/sites', user.token] : null, fetcher);
 
   if (!data) {
     return (

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { Button, Flex, Text, Code, Icon } from '@chakra-ui/core';
+import { Button, Flex, Text, Code, Icon, Link } from '@chakra-ui/core';
 
 import { useAuth } from '@/lib/auth';
 
@@ -13,18 +13,49 @@ const Home = () => {
       align="center"
       justify="center"
       h="100vh"
+      maxW="400px"
+      margin="0 auto"
     >
       <Head>
         <title>Fast Feedback</title>
+        <Head>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+                if (document.cookie && document.cookie.includes('auth')) {
+                  window.location.href = "/dashboard"
+                }
+              `
+            }}
+          />
+        </Head>
       </Head>
-
-      <Icon color="black" name="logo" size="64px" />
+      <Icon color="black" name="logo" size="42px" mb={2} />
+      <Text mb={4}>
+        <Text as="span" fontWeight="bold" display="inline">
+          Fast Feedback
+        </Text>
+        {' is being built as part of '}
+        <Link
+          href="https://react2025.com"
+          isExternal
+          textDecoration="underline"
+        >
+          React 2025
+        </Link>
+        {`. It's the easiest way to add comments or reviews to your static site. It's still a work-in-progress, but you can try it out by logging in.`}
+      </Text>
       {auth.user ? (
-        <Button as="a" href="/dashboard">
+        <Button as="a" size="sm" fontWeight="medium" href="/dashboard">
           View Dashboard
         </Button>
       ) : (
-        <Button mt={4} size="sm" onClick={(e) => auth.signinWithGitHub()}>
+        <Button
+          mt={4}
+          size="sm"
+          fontWeight="medium"
+          onClick={(e) => auth.signinWithGitHub()}
+        >
           Sign In
         </Button>
       )}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { Button, Flex, Text, Code, Icon, Link } from '@chakra-ui/core';
+import { Button, Flex, Text, Icon, Link } from '@chakra-ui/core';
 
 import { useAuth } from '@/lib/auth';
 
@@ -17,18 +17,16 @@ const Home = () => {
       margin="0 auto"
     >
       <Head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              if (document.cookie && document.cookie.includes('fast-feedback-auth')) {
+                window.location.href = "/dashboard"
+              }
+            `
+          }}
+        />
         <title>Fast Feedback</title>
-        <Head>
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
-                if (document.cookie && document.cookie.includes('auth')) {
-                  window.location.href = "/dashboard"
-                }
-              `
-            }}
-          />
-        </Head>
       </Head>
       <Icon color="black" name="logo" size="42px" mb={2} />
       <Text mb={4}>

--- a/pages/p/[siteId].js
+++ b/pages/p/[siteId].js
@@ -14,7 +14,8 @@ export async function getStaticProps(context) {
   return {
     props: {
       initialFeedback: feedback
-    }
+    },
+    unstable_revalidate: 1
   };
 }
 

--- a/utils/fetcher.js
+++ b/utils/fetcher.js
@@ -1,5 +1,9 @@
-export default async (...args) => {
-  const res = await fetch(...args);
+export default async (url, token) => {
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: new Headers({ 'Content-Type': 'application/json', token }),
+    credentials: 'same-origin'
+  });
 
   return res.json();
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4489,6 +4489,11 @@ jest-worker@24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
- Only show sites for the current user
    - Need context of user in API route
- Enforce authentication on API routes
    - Use Firebase to Verify API tokens
- Redirect to /dashboard if you're already logged in
    - https://vercel.com/blog/simple-auth-with-magic-link-and-nextjs
- Try out Incremental Static Regeneration
    - https://nextjs.org/blog/next-9-4#incremental-static-regeneration-beta

Closes FAS-6, FAS-7, FAS-8, FAS-9.