### PR TITLE
Updated auth.js to get valid token(Issue #25)

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -115,13 +115,14 @@ const getStripeRole = async () => {
 };
 
 const formatUser = async (user) => {
+  const token = await user.getIdToken();
   return {
     uid: user.uid,
     email: user.email,
     name: user.displayName,
-    token: user.xa,
     provider: user.providerData[0].providerId,
     photoUrl: user.photoURL,
-    stripeRole: await getStripeRole()
+    stripeRole: await getStripeRole(),
+    token
   };
 };


### PR DESCRIPTION
Getting token with `user.xa` , `ya` and in my case `za` is a mess, these properties tend to change. This way the tokens are not renewed here, in fact those properties simply are reassigned to false, then a new property is assigned with the refreshed token, + this is also not a documented way to get token. 

Refactored `formatUser` to get valid token using `getIdToken()`  as mentioned in [here](https://firebase.google.com/docs/reference/js/firebase.User#getidtoken)